### PR TITLE
add regression-test-forked-branch.yaml workflow

### DIFF
--- a/.github/workflows/regression-test-forked-branch.yaml
+++ b/.github/workflows/regression-test-forked-branch.yaml
@@ -1,0 +1,138 @@
+# Copyright 2019 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Regression Tests Forked Branch
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - remote-regression-test-runs
+  pull_request:
+    types: [labeled, opened, reopened, synchronize]
+    branches:
+      - remote-pre-merge-tests
+
+jobs:
+  run-regression-tests:
+    runs-on: ubuntu-24.04
+    if: >
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.fork == true
+      )
+    env:
+      REACT_APP_FUNCTION_CATALOG_URL: ${{ secrets.REACT_APP_FUNCTION_CATALOG_URL }}
+      REACT_APP_MLRUN_API_URL: ${{ secrets.REACT_APP_MLRUN_API_URL }}
+      REACT_APP_NUCLIO_API_URL: ${{ secrets.REACT_APP_NUCLIO_API_URL }}
+      REACT_APP_IGUAZIO_API_URL: ${{ secrets.REACT_APP_IGUAZIO_API_URL }}
+    outputs:
+      failed_step: ${{ steps.identify_failure.outputs.FAILED_STEP }}
+      job_status: ${{ job.status }}
+    steps:
+      - name: Checkout code
+        id: checkout_code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        id: setup_node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        id: install_dependencies
+        run: npm install
+
+      - name: Run parallel tasks
+        id: run_parallel_tasks
+        run: |
+          npm run add-comment-to-http-client &
+          npm run mock-server &
+          npm start &
+          npm run test:regression
+
+      - name: Upload test reports
+        id: upload_reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: tests/reports/
+          if-no-files-found: error
+
+      - name: Identify failed step
+        if: ${{ always() }}
+        id: identify_failure
+        run: |
+          FAILED_STEP=""
+          if [ "${{ steps.checkout_code.outcome }}" = "failure" ]; then
+            FAILED_STEP="Checkout code"
+          elif [ "${{ steps.setup_node.outcome }}" = "failure" ]; then
+            FAILED_STEP="Set up Node.js"
+          elif [ "${{ steps.install_dependencies.outcome }}" = "failure" ]; then
+            FAILED_STEP="Install dependencies"
+          elif [ "${{ steps.run_parallel_tasks.outcome }}" = "failure" ]; then
+            FAILED_STEP="Run parallel tasks"
+          elif [ "${{ steps.upload_reports.outcome }}" = "failure" ]; then
+            FAILED_STEP="Upload test reports" 
+          fi
+          echo "failed_step=$FAILED_STEP" >> $GITHUB_OUTPUT
+
+  comment-pr:
+    name: Regression Test - comment on PR
+    runs-on: ubuntu-24.04
+    needs: run-regression-tests
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == true && always()
+    env:
+      JOB_STATUS: ${{ needs.run-regression-tests.result }}
+      FAILED_STEP: ${{ needs.run-regression-tests.outputs.failed_step }}
+    steps:
+      - name: Post PR comment (success, failure, or cancelled)
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const jobStatus = process.env.JOB_STATUS;
+            const failedStep = process.env.FAILED_STEP;
+
+            if (jobStatus === 'success') {
+              github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: "**Regression Test workflow finished successfully.** ✅"
+              });
+            } else if (jobStatus === 'cancelled') {
+              github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: "**Regression Test workflow was cancelled.** ⚠️"
+              });
+            } else if (jobStatus === 'failure') {
+              let body = "**Regression Test workflow failed.** ❌";
+              if (failedStep) {
+                body += `\nFailed step: **${failedStep}**`;
+              } else {
+                body += "\nFailed step: Unknown";
+              }
+              github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }

--- a/.github/workflows/regression-test-forked-branch.yaml
+++ b/.github/workflows/regression-test-forked-branch.yaml
@@ -24,6 +24,10 @@ on:
     branches:
       - remote-pre-merge-tests
 
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   run-regression-tests:
     runs-on: ubuntu-24.04

--- a/.github/workflows/regression-test-forked-branch.yaml
+++ b/.github/workflows/regression-test-forked-branch.yaml
@@ -107,6 +107,7 @@ jobs:
     env:
       JOB_STATUS: ${{ needs.run-regression-tests.result }}
       FAILED_STEP: ${{ needs.run-regression-tests.outputs.failed_step }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Post PR comment (success, failure, or cancelled)
         uses: actions/github-script@v6
@@ -114,23 +115,29 @@ jobs:
           script: |
             const jobStatus = process.env.JOB_STATUS;
             const failedStep = process.env.FAILED_STEP;
-            
+
             const prOwner = context.payload.pull_request.head.repo.owner.login;
             const prRepo = context.payload.pull_request.head.repo.name;
-            
+
             if (jobStatus === 'success') {
               github.rest.issues.createComment({
                 owner: prOwner,
                 repo: prRepo,
                 issue_number: context.issue.number,
-                body: "**Regression Test workflow finished successfully.** ✅"
+                body: "**Regression Test workflow finished successfully.** ✅",
+                headers: {
+                  Authorization: `token ${process.env.GH_TOKEN}`
+                }
               });
             } else if (jobStatus === 'cancelled') {
               github.rest.issues.createComment({
                 owner: prOwner,
                 repo: prRepo,
                 issue_number: context.issue.number,
-                body: "**Regression Test workflow was cancelled.** ⚠️"
+                body: "**Regression Test workflow was cancelled.** ⚠️",
+                headers: {
+                  Authorization: `token ${process.env.GH_TOKEN}`
+                }
               });
             } else if (jobStatus === 'failure') {
               let body = "**Regression Test workflow failed.** ❌";
@@ -143,6 +150,9 @@ jobs:
                 owner: prOwner,
                 repo: prRepo,
                 issue_number: context.issue.number,
-                body: body
+                body: body,
+                headers: {
+                  Authorization: `token ${process.env.GH_TOKEN}`
+                }
               });
             }

--- a/.github/workflows/regression-test-forked-branch.yaml
+++ b/.github/workflows/regression-test-forked-branch.yaml
@@ -94,52 +94,55 @@ jobs:
           fi
           echo "failed_step=$FAILED_STEP" >> $GITHUB_OUTPUT
 
-comment-pr:
-  name: Regression Test - comment on PR
-  runs-on: ubuntu-24.04
-  needs: run-regression-tests
-  if: >
-    github.event_name == 'pull_request' &&
-    github.event.pull_request.head.repo.fork == true && always()
-  env:
-    JOB_STATUS: ${{ needs.run-regression-tests.result }}
-    FAILED_STEP: ${{ needs.run-regression-tests.outputs.failed_step }}
-  steps:
-    - name: Post PR comment (success, failure, or cancelled)
-      uses: actions/github-script@v6
-      with:
-        script: |
-          const jobStatus = process.env.JOB_STATUS;
-          const failedStep = process.env.FAILED_STEP;
 
-          const prOwner = context.payload.pull_request.head.repo.owner.login;
-          const prRepo = context.payload.pull_request.head.repo.name;
 
-          if (jobStatus === 'success') {
-            github.rest.issues.createComment({
-              owner: prOwner,
-              repo: prRepo,
-              issue_number: context.issue.number,
-              body: "**Regression Test workflow finished successfully.** ✅"
-            });
-          } else if (jobStatus === 'cancelled') {
-            github.rest.issues.createComment({
-              owner: prOwner,
-              repo: prRepo,
-              issue_number: context.issue.number,
-              body: "**Regression Test workflow was cancelled.** ⚠️"
-            });
-          } else if (jobStatus === 'failure') {
-            let body = "**Regression Test workflow failed.** ❌";
-            if (failedStep) {
-              body += `\nFailed step: **${failedStep}**`;
-            } else {
-              body += "\nFailed step: Unknown";
+
+  comment-pr:
+    name: Regression Test - comment on PR
+    runs-on: ubuntu-24.04
+    needs: run-regression-tests
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == true && always()
+    env:
+      JOB_STATUS: ${{ needs.run-regression-tests.result }}
+      FAILED_STEP: ${{ needs.run-regression-tests.outputs.failed_step }}
+    steps:
+      - name: Post PR comment (success, failure, or cancelled)
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const jobStatus = process.env.JOB_STATUS;
+            const failedStep = process.env.FAILED_STEP;
+            
+            const prOwner = context.payload.pull_request.head.repo.owner.login;
+            const prRepo = context.payload.pull_request.head.repo.name;
+            
+            if (jobStatus === 'success') {
+              github.rest.issues.createComment({
+                owner: prOwner,
+                repo: prRepo,
+                issue_number: context.issue.number,
+                body: "**Regression Test workflow finished successfully.** ✅"
+              });
+            } else if (jobStatus === 'cancelled') {
+              github.rest.issues.createComment({
+                owner: prOwner,
+                repo: prRepo,
+                issue_number: context.issue.number,
+                body: "**Regression Test workflow was cancelled.** ⚠️"
+              });
+            } else if (jobStatus === 'failure') {
+              let body = "**Regression Test workflow failed.** ❌";
+              if (failedStep) {
+                body += `\nFailed step: **${failedStep}**`;
+              } else {
+                body += "\nFailed step: Unknown";
+              }
+              github.rest.issues.createComment({
+                owner: prOwner,
+                repo: prRepo,
+                issue_number: context.issue.number,
+                body: body
+              });
             }
-            github.rest.issues.createComment({
-              owner: prOwner,
-              repo: prRepo,
-              issue_number: context.issue.number,
-              body: body
-            });
-          }

--- a/.github/workflows/regression-test-forked-branch.yaml
+++ b/.github/workflows/regression-test-forked-branch.yaml
@@ -94,49 +94,52 @@ jobs:
           fi
           echo "failed_step=$FAILED_STEP" >> $GITHUB_OUTPUT
 
-  comment-pr:
-    name: Regression Test - comment on PR
-    runs-on: ubuntu-24.04
-    needs: run-regression-tests
-    if: >
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.fork == true && always()
-    env:
-      JOB_STATUS: ${{ needs.run-regression-tests.result }}
-      FAILED_STEP: ${{ needs.run-regression-tests.outputs.failed_step }}
-    steps:
-      - name: Post PR comment (success, failure, or cancelled)
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const jobStatus = process.env.JOB_STATUS;
-            const failedStep = process.env.FAILED_STEP;
+comment-pr:
+  name: Regression Test - comment on PR
+  runs-on: ubuntu-24.04
+  needs: run-regression-tests
+  if: >
+    github.event_name == 'pull_request' &&
+    github.event.pull_request.head.repo.fork == true && always()
+  env:
+    JOB_STATUS: ${{ needs.run-regression-tests.result }}
+    FAILED_STEP: ${{ needs.run-regression-tests.outputs.failed_step }}
+  steps:
+    - name: Post PR comment (success, failure, or cancelled)
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const jobStatus = process.env.JOB_STATUS;
+          const failedStep = process.env.FAILED_STEP;
 
-            if (jobStatus === 'success') {
-              github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: "**Regression Test workflow finished successfully.** ✅"
-              });
-            } else if (jobStatus === 'cancelled') {
-              github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: "**Regression Test workflow was cancelled.** ⚠️"
-              });
-            } else if (jobStatus === 'failure') {
-              let body = "**Regression Test workflow failed.** ❌";
-              if (failedStep) {
-                body += `\nFailed step: **${failedStep}**`;
-              } else {
-                body += "\nFailed step: Unknown";
-              }
-              github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
+          const prOwner = context.payload.pull_request.head.repo.owner.login;
+          const prRepo = context.payload.pull_request.head.repo.name;
+
+          if (jobStatus === 'success') {
+            github.rest.issues.createComment({
+              owner: prOwner,
+              repo: prRepo,
+              issue_number: context.issue.number,
+              body: "**Regression Test workflow finished successfully.** ✅"
+            });
+          } else if (jobStatus === 'cancelled') {
+            github.rest.issues.createComment({
+              owner: prOwner,
+              repo: prRepo,
+              issue_number: context.issue.number,
+              body: "**Regression Test workflow was cancelled.** ⚠️"
+            });
+          } else if (jobStatus === 'failure') {
+            let body = "**Regression Test workflow failed.** ❌";
+            if (failedStep) {
+              body += `\nFailed step: **${failedStep}**`;
+            } else {
+              body += "\nFailed step: Unknown";
             }
+            github.rest.issues.createComment({
+              owner: prOwner,
+              repo: prRepo,
+              issue_number: context.issue.number,
+              body: body
+            });
+          }


### PR DESCRIPTION
Runs regression tests for forked branches and comments on PRs.

**### Branches**

- Push events → Runs on remote-regression-test-runs.
- Pull requests → Runs on remote-pre-merge-tests when labeled, opened, reopened, or synchronized.

**### Jobs**

**run-regression-tests 🧪**

- Triggers on push events and forked PRs.
- Sets up Node.js, installs dependencies, and runs regression tests in parallel.
- Uploads test reports as artifacts (tests/reports/).
- Identifies failed steps for debugging.

**comment-pr 💬**

- Runs on forked PRs, always executes.
- Comments on the PR with test results (success, failure, or cancellation).